### PR TITLE
Require target framework standard 2.0 instead of core 3.0

### DIFF
--- a/src/EFCore.Temporal.Query/AsOfQuerySqlGeneratorFactory.cs
+++ b/src/EFCore.Temporal.Query/AsOfQuerySqlGeneratorFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal;
 
@@ -12,11 +12,11 @@ namespace EntityFrameworkCore.TemporalTables.Query
         private readonly QueryCompilationContext _queryCompilationContext;
 
         public AsOfQuerySqlGeneratorFactory(
-            QuerySqlGeneratorDependencies dependencies,
-            ISqlServerOptions sqlServerOptions)
+            [NotNull] QuerySqlGeneratorDependencies dependencies,
+            [NotNull] ISqlServerOptions sqlServerOptions)
         {
-            _dependencies = dependencies ?? throw new ArgumentNullException(nameof(dependencies));
-            _sqlServerOptions = sqlServerOptions ?? throw new ArgumentNullException(nameof(sqlServerOptions));
+            _dependencies = dependencies;
+            _sqlServerOptions = sqlServerOptions;
         }
 
         public QuerySqlGenerator Create()

--- a/src/EFCore.Temporal.Query/AsOfQuerySqlGeneratorFactory.cs
+++ b/src/EFCore.Temporal.Query/AsOfQuerySqlGeneratorFactory.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Query;
+﻿using System;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal;
 
 namespace EntityFrameworkCore.TemporalTables.Query
@@ -14,8 +15,8 @@ namespace EntityFrameworkCore.TemporalTables.Query
             QuerySqlGeneratorDependencies dependencies,
             ISqlServerOptions sqlServerOptions)
         {
-            _dependencies = dependencies;
-            _sqlServerOptions = sqlServerOptions;
+            _dependencies = dependencies ?? throw new ArgumentNullException(nameof(dependencies));
+            _sqlServerOptions = sqlServerOptions ?? throw new ArgumentNullException(nameof(sqlServerOptions));
         }
 
         public QuerySqlGenerator Create()

--- a/src/EFCore.Temporal.Query/AsOfQuerySqlGeneratorFactory.cs
+++ b/src/EFCore.Temporal.Query/AsOfQuerySqlGeneratorFactory.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal;
-using System.Diagnostics.CodeAnalysis;
 
 namespace EntityFrameworkCore.TemporalTables.Query
 {
@@ -12,8 +11,8 @@ namespace EntityFrameworkCore.TemporalTables.Query
         private readonly QueryCompilationContext _queryCompilationContext;
 
         public AsOfQuerySqlGeneratorFactory(
-            [NotNull] QuerySqlGeneratorDependencies dependencies,
-            [NotNull] ISqlServerOptions sqlServerOptions)
+            QuerySqlGeneratorDependencies dependencies,
+            ISqlServerOptions sqlServerOptions)
         {
             _dependencies = dependencies;
             _sqlServerOptions = sqlServerOptions;

--- a/src/EFCore.Temporal.Query/AsOfQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Temporal.Query/AsOfQueryableMethodTranslatingExpressionVisitor.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;

--- a/src/EFCore.Temporal.Query/EFCore.Temporal.Query.csproj
+++ b/src/EFCore.Temporal.Query/EFCore.Temporal.Query.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Dabble.EntityFrameworkCore.Temporal.Query</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore.Temporal.Query</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/EFCore.Temporal.Query/EFCore.Temporal.Query.csproj
+++ b/src/EFCore.Temporal.Query/EFCore.Temporal.Query.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <MinClientVersion>3.6</MinClientVersion>
     <AssemblyName>Dabble.EntityFrameworkCore.Temporal.Query</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore.Temporal.Query</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -25,6 +26,7 @@ https://www.flaticon.com/authors/smashicons</Description>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.1" />
   </ItemGroup>

--- a/src/EFCore.Temporal.Query/Extensions/SqlServerEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Temporal.Query/Extensions/SqlServerEntityTypeBuilderExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore
             return entity;
         }
 
-        public static DbContextOptionsBuilder<TContext> EnableTemporalTableQueries<TContext>([NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder) where TContext : DbContext
+        public static DbContextOptionsBuilder<TContext> EnableTemporalTableQueries<TContext>(this DbContextOptionsBuilder<TContext> optionsBuilder) where TContext : DbContext
         {
             // If service provision is NOT being performed internally, we cannot replace services.
             var coreOptions = optionsBuilder.Options.GetExtension<CoreOptionsExtension>();

--- a/src/EFCore.Temporal.Query/Extensions/SqlServerEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Temporal.Query/Extensions/SqlServerEntityTypeBuilderExtensions.cs
@@ -1,9 +1,8 @@
-﻿using System;
 using EntityFrameworkCore.TemporalTables.Query;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Query;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -17,13 +16,8 @@ namespace Microsoft.EntityFrameworkCore
             return entity;
         }
 
-        public static DbContextOptionsBuilder<TContext> EnableTemporalTableQueries<TContext>(this DbContextOptionsBuilder<TContext> optionsBuilder) where TContext : DbContext
+        public static DbContextOptionsBuilder EnableTemporalTableQueries([NotNull] this DbContextOptionsBuilder optionsBuilder)
         {
-            if (optionsBuilder == null)
-            {
-                throw new ArgumentNullException(nameof(optionsBuilder));
-            }
-
             // If service provision is NOT being performed internally, we cannot replace services.
             var coreOptions = optionsBuilder.Options.GetExtension<CoreOptionsExtension>();
             if (coreOptions.InternalServiceProvider == null)

--- a/src/EFCore.Temporal.Query/Extensions/SqlServerEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Temporal.Query/Extensions/SqlServerEntityTypeBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using EntityFrameworkCore.TemporalTables.Query;
+﻿using System;
+using EntityFrameworkCore.TemporalTables.Query;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Query;
@@ -18,6 +19,11 @@ namespace Microsoft.EntityFrameworkCore
 
         public static DbContextOptionsBuilder<TContext> EnableTemporalTableQueries<TContext>(this DbContextOptionsBuilder<TContext> optionsBuilder) where TContext : DbContext
         {
+            if (optionsBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(optionsBuilder));
+            }
+
             // If service provision is NOT being performed internally, we cannot replace services.
             var coreOptions = optionsBuilder.Options.GetExtension<CoreOptionsExtension>();
             if (coreOptions.InternalServiceProvider == null)


### PR DESCRIPTION
Our data layer targets standard 2.1 framework, I'd like to avoid having to change it to core 3.1. The only usage of core 3.0 were the [NotNull] attributes. I've replaced them by explicit null checks.